### PR TITLE
Fix index out of range issue

### DIFF
--- a/LowercaseDashedRouting/LowercaseDashedRoute.cs
+++ b/LowercaseDashedRouting/LowercaseDashedRoute.cs
@@ -198,6 +198,9 @@ namespace LowercaseDashedRouting
 
 		protected static string AddDashesForMatchingUrl(string url)
 		{
+			if(url.Length == 0)
+				return url;
+			
 			var newText = new StringBuilder(url.Length * 2);
 			newText.Append(char.ToLower(url[0]));
 


### PR DESCRIPTION
If an empty string makes it into AddDashesForMatchingUrl it should just return instead of throwing exception